### PR TITLE
Dependency update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ipfs-key
 A tool for easily generating ipfs keypairs. When run, it will write the bytes of
 the serialized private key to stdout. By default, a 2048 bit RSA key will be
-generated. The keysize can be changed by specifying the `-size` option, and the
+generated. The keysize can be changed by specifying the `-bitsize` option, and the
 key type can be changed by specifying the `-type` option (currently only RSA is
 implemented).
 
@@ -12,5 +12,5 @@ $ go get github.com/whyrusleeping/ipfs-key
 
 ## Usage
 ```
-$ ipfs-key -size=4096 > my.key
+$ ipfs-key -bitsize=4096 > my.key
 ```

--- a/main.go
+++ b/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	ci "github.com/ipfs/go-libp2p/p2p/crypto"
-	peer "github.com/ipfs/go-libp2p/p2p/peer"
+	ci "github.com/ipfs/go-libp2p-crypto"
+	peer "github.com/ipfs/go-libp2p-peer"
 )
 
 func main() {


### PR DESCRIPTION
The crypto and peer dependencies appear to have moved out of the go-libp2p repo. I have updated the deps to point at the new seperate github repos. There is also a small update to the usage section of the readme.
