### PR TITLE
Added Ed25519 key type

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ When run, it will write the bytes of
 the serialized private key to stdout. By default, a 2048 bit RSA key will be
 generated. In this case the key size can be changed by specifying the `-bitsize`
 option. The key type can be changed by specifying the `-type` option (rsa or
-ed25519). Currently only the RSA uses the -bitsize option.
+ed25519).
 
 ```
 $ ipfs-key -bitsize=4096 > my-rsa4096.key

--- a/README.md
+++ b/README.md
@@ -1,16 +1,39 @@
 # ipfs-key
-A tool for easily generating ipfs keypairs. When run, it will write the bytes of
-the serialized private key to stdout. By default, a 2048 bit RSA key will be
-generated. The keysize can be changed by specifying the `-bitsize` option, and the
-key type can be changed by specifying the `-type` option (currently only RSA is
-implemented).
+
+[![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+
+> A tool for easily generating ipfs keypairs
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [Contribute](#contribute)
+- [License](#license)
 
 ## Installation
+
 ```
 $ go get github.com/whyrusleeping/ipfs-key
 ```
 
 ## Usage
+
+When run, it will write the bytes of
+the serialized private key to stdout. By default, a 2048 bit RSA key will be
+generated. In this case the key size can be changed by specifying the `-bitsize`
+option. The key type can be changed by specifying the `-type` option (rsa or
+ed25519). Currently only the RSA uses the -bitsize option.
+
 ```
-$ ipfs-key -bitsize=4096 > my.key
+$ ipfs-key -bitsize=4096 > my-rsa4096.key
+$ ipfs-key -type=ed25519 > my-ed.key
 ```
+
+## Contribute
+
+PRs accepted.
+
+## License
+
+[MIT](LICENSE) Copyright (c) 2016 [Jeromy Johnson](http://github.com/whyrusleeping)

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 
 	ci "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
+	"strings"
 )
 
 func main() {
@@ -16,10 +17,10 @@ func main() {
 	flag.Parse()
 
 	var atyp int
-	switch *typ {
-	case "RSA":
+	switch strings.ToLower(*typ) {
+	case "rsa":
 		atyp = ci.RSA
-	case "Ed25519":
+	case "ed25519":
 		atyp = ci.Ed25519
 	default:
 		fmt.Fprintln(os.Stderr, "unrecognized key type: ", *typ)

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	size := flag.Int("bitsize", 2048, "select the bitsize of the key to generate")
-	typ := flag.String("type", "RSA", "select type of key to generate")
+	typ := flag.String("type", "RSA", "select type of key to generate (RSA or Ed25519)")
 
 	flag.Parse()
 
@@ -19,6 +19,8 @@ func main() {
 	switch *typ {
 	case "RSA":
 		atyp = ci.RSA
+	case "Ed25519":
+		atyp = ci.Ed25519
 	default:
 		fmt.Fprintln(os.Stderr, "unrecognized key type: ", *typ)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -4,10 +4,10 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	ci "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
-	"strings"
 )
 
 func main() {


### PR DESCRIPTION
I know that `ipfs key gen` is in the ipfs/go-ipfs master branch already, but we should not let this nice little tool behind. Libp2p supports a newer key type, so I added it here, too.